### PR TITLE
feat: add calendar integration for bookings with .ics download and LI…

### DIFF
--- a/android-app/README.md
+++ b/android-app/README.md
@@ -52,9 +52,18 @@ app/
 
 ## 後端 API 連接設定
 
-預設 API Base URL: `http://10.0.2.2:8080/`
-- `10.0.2.2` 是 Android Emulator 訪問本機 localhost 的特殊 IP
-- 如果使用實體設備測試，請修改 `NetworkModule.kt` 中的 `BASE_URL`
+App 支援多環境切換，透過 `EnvironmentManager.kt` 管理：
+
+| 環境 | Base URL | 說明 |
+|------|----------|------|
+| 開發環境 | `http://172.20.10.2:8080/` | iPhone 熱點下電腦的固定 IP |
+| 測試環境 | `https://staging-api.petcare.com/` | Staging 伺服器 |
+| 正式環境 | `https://api.petcare.com/` | Production 伺服器 |
+
+**注意**：
+- `172.20.10.2` 是 iPhone 熱點下電腦的固定 IP
+- 若使用 Android Emulator 連接 localhost，需改為 `10.0.2.2`
+- 環境設定存在 DataStore，App 重啟後會保留
 
 ## 建置專案
 
@@ -111,6 +120,7 @@ app/
 ## 注意事項
 
 1. 確保後端 Spring Boot 服務已啟動
-2. Android Emulator 使用 `10.0.2.2` 連接本機
-3. 實體設備需要修改為電腦的實際 IP 位址
-4. 確保後端 CORS 設定允許來自 Android 的請求
+2. iPhone 熱點：電腦 IP 固定為 `172.20.10.2`
+3. Android Emulator：使用 `10.0.2.2` 連接本機 localhost
+4. 同一 WiFi：使用電腦的實際 IP 位址
+5. 確保後端 CORS 設定允許來自 Android 的請求

--- a/android-app/app/src/main/java/com/pet/android/data/preferences/EnvironmentManager.kt
+++ b/android-app/app/src/main/java/com/pet/android/data/preferences/EnvironmentManager.kt
@@ -23,7 +23,9 @@ class EnvironmentManager @Inject constructor(
     }
 
     enum class Environment(val displayName: String, val baseUrl: String) {
-        DEVELOPMENT("開發環境", "http://10.0.2.2:8080/"),
+        // 172.20.10.2 = iPhone 熱點下電腦的固定 IP
+        // 10.0.2.2 = Android 模擬器存取 localhost 的特殊 IP
+        DEVELOPMENT("開發環境", "http://172.20.10.2:8080/"),
         STAGING("測試環境", "https://staging-api.petcare.com/"),
         PRODUCTION("正式環境", "https://api.petcare.com/")
     }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
       - LINE_CHANNEL_TOKEN=${LINE_CHANNEL_TOKEN}
       - LINE_CHANNEL_SECRET=${LINE_CHANNEL_SECRET}
       - LINE_DEMO_USER_ID=${LINE_DEMO_USER_ID}
+      - LINE_BASE_URL=${LINE_BASE_URL}
     ports:
       - "${SERVER_PORT:-8080}:8080"
     volumes:

--- a/docker-compose.qas.yml
+++ b/docker-compose.qas.yml
@@ -53,6 +53,7 @@ services:
       - LINE_CHANNEL_TOKEN=${LINE_CHANNEL_TOKEN}
       - LINE_CHANNEL_SECRET=${LINE_CHANNEL_SECRET}
       - LINE_DEMO_USER_ID=${LINE_DEMO_USER_ID}
+      - LINE_BASE_URL=${LINE_BASE_URL}
     ports:
       - "${SERVER_PORT:-8080}:8080"
     depends_on:

--- a/src/main/java/com/pet/config/LineMessagingConfig.java
+++ b/src/main/java/com/pet/config/LineMessagingConfig.java
@@ -16,8 +16,19 @@ public class LineMessagingConfig {
     private String demoUserId;
     private boolean enabled = true;
 
+    /**
+     * 系統的公開 Base URL（用於產生行事曆連結）
+     * 例如：http://192.168.1.100:8080 或 https://abc123.ngrok.io
+     * 若未設定，LINE 訊息中將不包含行事曆連結
+     */
+    private String baseUrl;
+
     public boolean isConfigured() {
         return channelToken != null && !channelToken.isEmpty()
             && demoUserId != null && !demoUserId.isEmpty();
+    }
+
+    public boolean hasBaseUrl() {
+        return baseUrl != null && !baseUrl.isEmpty();
     }
 }

--- a/src/main/java/com/pet/config/SecurityConfig.java
+++ b/src/main/java/com/pet/config/SecurityConfig.java
@@ -88,6 +88,9 @@ public class SecurityConfig {
                                 // 健康檢查端點（給 K8s probe / 監控系統用）
                                 .requestMatchers("/api/health/**").permitAll()
 
+                                // 行事曆頁面與下載（LINE 訊息連結，不需登入）
+                                .requestMatchers("/api/bookings/*/calendar", "/api/bookings/*/calendar/download").permitAll()
+
                                 // H2 Console（僅開發環境用）
 //                        .requestMatchers("/h2-console/**").permitAll()
 

--- a/src/main/java/com/pet/service/CalendarService.java
+++ b/src/main/java/com/pet/service/CalendarService.java
@@ -1,0 +1,140 @@
+package com.pet.service;
+
+import com.pet.domain.Booking;
+import com.pet.exception.ResourceNotFoundException;
+import com.pet.repository.BookingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * 行事曆服務
+ * 產生 iCalendar (.ics) 格式的行事曆事件
+ */
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+
+    private static final DateTimeFormatter ICS_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
+    private static final ZoneId TAIPEI_ZONE = ZoneId.of("Asia/Taipei");
+
+    private final BookingRepository bookingRepository;
+
+    /**
+     * 產生預約的 iCalendar (.ics) 內容
+     *
+     * @param bookingId 預約 ID
+     * @return .ics 檔案內容
+     */
+    public String generateBookingCalendar(UUID bookingId) {
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new ResourceNotFoundException("預約", "id", bookingId));
+
+        return generateIcsContent(booking);
+    }
+
+    /**
+     * 產生 iCalendar 內容
+     * 格式遵循 RFC 5545 標準
+     */
+    private String generateIcsContent(Booking booking) {
+        String petName = booking.getPet().getName();
+        String sitterName = booking.getSitter().getName();
+        String startTime = booking.getStartTime().format(ICS_DATE_FORMAT);
+        String endTime = booking.getEndTime().format(ICS_DATE_FORMAT);
+        String uid = "booking-" + booking.getId() + "@petcare.com";
+        String createdAt = booking.getCreatedAt() != null
+                ? booking.getCreatedAt().format(ICS_DATE_FORMAT)
+                : startTime;
+
+        // 事件摘要
+        String summary = String.format("寵物保母預約 - %s", petName);
+
+        // 事件描述
+        StringBuilder description = new StringBuilder();
+        description.append("寵物：").append(petName).append("\\n");
+        description.append("保母：").append(sitterName).append("\\n");
+        description.append("費用：$").append(String.format("%.0f", booking.getTotalPrice())).append("\\n");
+        description.append("狀態：").append(getStatusText(booking.getStatus())).append("\\n");
+        if (booking.getNotes() != null && !booking.getNotes().isEmpty()) {
+            description.append("備註：").append(booking.getNotes().replace("\n", "\\n"));
+        }
+
+        // 組裝 iCalendar 內容
+        StringBuilder ics = new StringBuilder();
+        ics.append("BEGIN:VCALENDAR\r\n");
+        ics.append("VERSION:2.0\r\n");
+        ics.append("PRODID:-//Pet Care System//Booking Calendar//TW\r\n");
+        ics.append("CALSCALE:GREGORIAN\r\n");
+        ics.append("METHOD:PUBLISH\r\n");
+        ics.append("X-WR-TIMEZONE:Asia/Taipei\r\n");
+
+        // 時區定義
+        ics.append("BEGIN:VTIMEZONE\r\n");
+        ics.append("TZID:Asia/Taipei\r\n");
+        ics.append("X-LIC-LOCATION:Asia/Taipei\r\n");
+        ics.append("BEGIN:STANDARD\r\n");
+        ics.append("TZOFFSETFROM:+0800\r\n");
+        ics.append("TZOFFSETTO:+0800\r\n");
+        ics.append("TZNAME:CST\r\n");
+        ics.append("DTSTART:19700101T000000\r\n");
+        ics.append("END:STANDARD\r\n");
+        ics.append("END:VTIMEZONE\r\n");
+
+        // 事件
+        ics.append("BEGIN:VEVENT\r\n");
+        ics.append("UID:").append(uid).append("\r\n");
+        ics.append("DTSTAMP:").append(createdAt).append("\r\n");
+        ics.append("DTSTART;TZID=Asia/Taipei:").append(startTime).append("\r\n");
+        ics.append("DTEND;TZID=Asia/Taipei:").append(endTime).append("\r\n");
+        ics.append("SUMMARY:").append(summary).append("\r\n");
+        ics.append("DESCRIPTION:").append(description).append("\r\n");
+        ics.append("STATUS:").append(getIcsStatus(booking.getStatus())).append("\r\n");
+
+        // 提醒（預約前 1 小時）
+        ics.append("BEGIN:VALARM\r\n");
+        ics.append("TRIGGER:-PT1H\r\n");
+        ics.append("ACTION:DISPLAY\r\n");
+        ics.append("DESCRIPTION:寵物保母預約提醒：").append(petName).append(" 的保母服務即將開始\r\n");
+        ics.append("END:VALARM\r\n");
+
+        // 提醒（預約前 1 天）
+        ics.append("BEGIN:VALARM\r\n");
+        ics.append("TRIGGER:-P1D\r\n");
+        ics.append("ACTION:DISPLAY\r\n");
+        ics.append("DESCRIPTION:明天有寵物保母預約：").append(petName).append("\r\n");
+        ics.append("END:VALARM\r\n");
+
+        ics.append("END:VEVENT\r\n");
+        ics.append("END:VCALENDAR\r\n");
+
+        return ics.toString();
+    }
+
+    /**
+     * 取得狀態的中文顯示文字
+     */
+    private String getStatusText(Booking.BookingStatus status) {
+        return switch (status) {
+            case PENDING -> "待確認";
+            case CONFIRMED -> "已確認";
+            case CANCELLED -> "已取消";
+            case REJECTED -> "已拒絕";
+            case COMPLETED -> "已完成";
+        };
+    }
+
+    /**
+     * 取得 iCalendar 標準的狀態值
+     */
+    private String getIcsStatus(Booking.BookingStatus status) {
+        return switch (status) {
+            case CONFIRMED -> "CONFIRMED";
+            case CANCELLED, REJECTED -> "CANCELLED";
+            default -> "TENTATIVE";
+        };
+    }
+}

--- a/src/main/java/com/pet/service/LineMessagingService.java
+++ b/src/main/java/com/pet/service/LineMessagingService.java
@@ -28,20 +28,29 @@ public class LineMessagingService {
      * 發送預約確認通知
      */
     public void sendBookingConfirmedNotification(Booking booking) {
-        String message = String.format(
+        StringBuilder message = new StringBuilder();
+        message.append(String.format(
             "✅ 您的預約已確認！\n\n" +
             "🐾 寵物：%s\n" +
             "👤 保母：%s\n" +
             "📅 時間：%s ~ %s\n" +
-            "💰 費用：$%.0f\n\n" +
-            "感謝您使用寵物保母系統！",
+            "💰 費用：$%.0f\n",
             booking.getPet().getName(),
             booking.getSitter().getName(),
             booking.getStartTime().format(DATE_FORMATTER),
             booking.getEndTime().format(DATE_FORMATTER),
             booking.getTotalPrice()
-        );
-        sendNotification(message);
+        ));
+
+        // 如果有設定 baseUrl，加入行事曆連結
+        if (config.hasBaseUrl()) {
+            String calendarUrl = String.format("%s/api/bookings/%s/calendar",
+                    config.getBaseUrl(), booking.getId());
+            message.append("\n📅 加入行事曆：\n").append(calendarUrl).append("\n");
+        }
+
+        message.append("\n感謝您使用寵物保母系統！");
+        sendNotification(message.toString());
     }
 
     /**

--- a/src/main/java/com/pet/web/BookingController.java
+++ b/src/main/java/com/pet/web/BookingController.java
@@ -4,11 +4,15 @@ import com.pet.dto.BookingDto;
 import com.pet.dto.BookingStatusUpdateDto;
 import com.pet.dto.response.ApiResponse;
 import com.pet.service.BookingService;
+import com.pet.service.CalendarService;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
@@ -20,9 +24,11 @@ import java.util.UUID;
 public class BookingController {
 
     private final BookingService bookingService;
+    private final CalendarService calendarService;
 
-    public BookingController(BookingService bookingService) {
+    public BookingController(BookingService bookingService, CalendarService calendarService) {
         this.bookingService = bookingService;
+        this.calendarService = calendarService;
     }
 
     /**
@@ -56,6 +62,81 @@ public class BookingController {
     public ResponseEntity<ApiResponse<BookingDto>> getBooking(@PathVariable UUID id) {
         BookingDto booking = bookingService.getBookingById(id);
         return ResponseEntity.ok(ApiResponse.success(booking));
+    }
+
+    /**
+     * 下載預約行事曆 (.ics 檔案)
+     * GET /api/bookings/{id}/calendar
+     *
+     * 用途：
+     * - 讓用戶將預約加入 iPhone/Google/Outlook 行事曆
+     * - LINE 通知中附帶此連結
+     *
+     * 回傳：
+     * - Content-Type: text/calendar
+     * - Content-Disposition: attachment; filename="booking-{id}.ics"
+     */
+    @GetMapping("/{id}/calendar")
+    public ResponseEntity<String> calendarPage(@PathVariable UUID id) {
+        // 驗證預約存在
+        calendarService.generateBookingCalendar(id);
+
+        String downloadUrl = "/api/bookings/" + id + "/calendar/download";
+        String html = """
+                <!DOCTYPE html>
+                <html lang="zh-TW">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <title>加入行事曆 - 寵物保母預約</title>
+                    <style>
+                        * { margin: 0; padding: 0; box-sizing: border-box; }
+                        body { font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+                               background: linear-gradient(135deg, #667eea 0%%, #764ba2 100%%);
+                               min-height: 100vh; display: flex; align-items: center; justify-content: center; }
+                        .card { background: white; border-radius: 20px; padding: 40px 30px;
+                                max-width: 360px; width: 90%%; text-align: center;
+                                box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
+                        .icon { font-size: 64px; margin-bottom: 16px; }
+                        h1 { font-size: 20px; color: #333; margin-bottom: 8px; }
+                        p { font-size: 14px; color: #666; margin-bottom: 24px; line-height: 1.6; }
+                        .btn { display: inline-block; background: #4CAF50; color: white;
+                               padding: 14px 32px; border-radius: 12px; text-decoration: none;
+                               font-size: 16px; font-weight: 600; width: 100%%;
+                               transition: background 0.2s; }
+                        .btn:active { background: #388E3C; }
+                        .hint { font-size: 12px; color: #999; margin-top: 16px; }
+                    </style>
+                </head>
+                <body>
+                    <div class="card">
+                        <div class="icon">📅</div>
+                        <h1>寵物保母預約</h1>
+                        <p>點擊下方按鈕將預約加入您的行事曆</p>
+                        <a class="btn" href="%s">加入行事曆</a>
+                        <p class="hint">支援 iPhone 行事曆 / Google 日曆 / Outlook</p>
+                    </div>
+                </body>
+                </html>
+                """.formatted(downloadUrl);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_HTML)
+                .body(html);
+    }
+
+    @GetMapping("/{id}/calendar/download")
+    public ResponseEntity<byte[]> downloadCalendar(@PathVariable UUID id) {
+        String icsContent = calendarService.generateBookingCalendar(id);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.parseMediaType("text/calendar; charset=utf-8"));
+        headers.setContentDispositionFormData("attachment", "booking-" + id + ".ics");
+        headers.set("Content-Description", "Pet Care Booking Calendar");
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(icsContent.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -42,3 +42,7 @@ line:
     channel-secret: ${LINE_CHANNEL_SECRET:}
     demo-user-id: ${LINE_DEMO_USER_ID:}
     enabled: true
+    # 系統公開網址（用於 LINE 訊息中的行事曆連結）
+    # 本機開發：http://192.168.x.x:8080（同 WiFi 下手機可存取）
+    # 使用 ngrok：https://xxx.ngrok.io
+    base-url: ${LINE_BASE_URL:}

--- a/src/main/resources/application-qas.yml
+++ b/src/main/resources/application-qas.yml
@@ -44,3 +44,5 @@ line:
     channel-secret: ${LINE_CHANNEL_SECRET:}
     demo-user-id: ${LINE_DEMO_USER_ID:}
     enabled: true
+    # 系統公開網址（用於 LINE 訊息中的行事曆連結）
+    base-url: ${LINE_BASE_URL:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,5 @@ line:
     # Demo mode: all notifications go to this user (for interview demo)
     demo-user-id: ${LINE_DEMO_USER_ID:}
     enabled: true
+    # 系統公開網址（用於 LINE 訊息中的行事曆連結）
+    base-url: ${LINE_BASE_URL:}

--- a/src/test/java/com/pet/controller/BookingControllerCalendarTest.java
+++ b/src/test/java/com/pet/controller/BookingControllerCalendarTest.java
@@ -1,0 +1,190 @@
+package com.pet.controller;
+
+import com.pet.service.BookingService;
+import com.pet.service.CalendarService;
+import com.pet.exception.ResourceNotFoundException;
+import com.pet.web.BookingController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BookingController 行事曆端點測試")
+class BookingControllerCalendarTest {
+
+    @Mock
+    private BookingService bookingService;
+
+    @Mock
+    private CalendarService calendarService;
+
+    private BookingController bookingController;
+
+    private UUID testBookingId;
+    private static final String SAMPLE_ICS = """
+            BEGIN:VCALENDAR\r
+            VERSION:2.0\r
+            BEGIN:VEVENT\r
+            SUMMARY:寵物保母預約 - 喵喵\r
+            END:VEVENT\r
+            END:VCALENDAR\r
+            """;
+
+    @BeforeEach
+    void setUp() {
+        bookingController = new BookingController(bookingService, calendarService);
+        testBookingId = UUID.randomUUID();
+    }
+
+    @Nested
+    @DisplayName("GET /{id}/calendar - 行事曆頁面")
+    class CalendarPageTests {
+
+        @Test
+        @DisplayName("應該回傳 HTML 頁面")
+        void shouldReturnHtmlPage() {
+            // given
+            given(calendarService.generateBookingCalendar(testBookingId)).willReturn(SAMPLE_ICS);
+
+            // when
+            ResponseEntity<String> response = bookingController.calendarPage(testBookingId);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.TEXT_HTML);
+        }
+
+        @Test
+        @DisplayName("HTML 頁面應包含下載連結")
+        void shouldContainDownloadLink() {
+            // given
+            given(calendarService.generateBookingCalendar(testBookingId)).willReturn(SAMPLE_ICS);
+
+            // when
+            ResponseEntity<String> response = bookingController.calendarPage(testBookingId);
+
+            // then
+            String body = response.getBody();
+            assertThat(body).isNotNull();
+            assertThat(body).contains("/api/bookings/" + testBookingId + "/calendar/download");
+            assertThat(body).contains("加入行事曆");
+        }
+
+        @Test
+        @DisplayName("HTML 頁面應包含完整結構")
+        void shouldContainCompleteHtmlStructure() {
+            // given
+            given(calendarService.generateBookingCalendar(testBookingId)).willReturn(SAMPLE_ICS);
+
+            // when
+            ResponseEntity<String> response = bookingController.calendarPage(testBookingId);
+
+            // then
+            String body = response.getBody();
+            assertThat(body).contains("<!DOCTYPE html>");
+            assertThat(body).contains("寵物保母預約");
+            assertThat(body).contains("📅");
+        }
+
+        @Test
+        @DisplayName("預約不存在時應拋出例外")
+        void shouldThrowWhenBookingNotFound() {
+            // given
+            UUID nonExistentId = UUID.randomUUID();
+            given(calendarService.generateBookingCalendar(nonExistentId))
+                    .willThrow(new ResourceNotFoundException("預約", "id", nonExistentId));
+
+            // when & then
+            assertThatThrownBy(() -> bookingController.calendarPage(nonExistentId))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /{id}/calendar/download - 下載 .ics 檔案")
+    class CalendarDownloadTests {
+
+        @Test
+        @DisplayName("應該回傳 200 狀態碼")
+        void shouldReturn200() {
+            // given
+            given(calendarService.generateBookingCalendar(testBookingId)).willReturn(SAMPLE_ICS);
+
+            // when
+            ResponseEntity<byte[]> response = bookingController.downloadCalendar(testBookingId);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        @DisplayName("應該回傳 text/calendar Content-Type")
+        void shouldReturnCalendarContentType() {
+            // given
+            given(calendarService.generateBookingCalendar(testBookingId)).willReturn(SAMPLE_ICS);
+
+            // when
+            ResponseEntity<byte[]> response = bookingController.downloadCalendar(testBookingId);
+
+            // then
+            assertThat(response.getHeaders().getContentType().toString())
+                    .contains("text/calendar");
+        }
+
+        @Test
+        @DisplayName("應該包含 Content-Disposition attachment header")
+        void shouldContainContentDisposition() {
+            // given
+            given(calendarService.generateBookingCalendar(testBookingId)).willReturn(SAMPLE_ICS);
+
+            // when
+            ResponseEntity<byte[]> response = bookingController.downloadCalendar(testBookingId);
+
+            // then
+            String disposition = response.getHeaders().getContentDisposition().toString();
+            assertThat(disposition).contains("booking-" + testBookingId + ".ics");
+        }
+
+        @Test
+        @DisplayName("應該回傳正確的 .ics 內容")
+        void shouldReturnCorrectIcsContent() {
+            // given
+            given(calendarService.generateBookingCalendar(testBookingId)).willReturn(SAMPLE_ICS);
+
+            // when
+            ResponseEntity<byte[]> response = bookingController.downloadCalendar(testBookingId);
+
+            // then
+            assertThat(response.getBody()).isNotNull();
+            String content = new String(response.getBody());
+            assertThat(content).contains("BEGIN:VCALENDAR");
+            assertThat(content).contains("寵物保母預約 - 喵喵");
+        }
+
+        @Test
+        @DisplayName("預約不存在時應拋出例外")
+        void shouldThrowWhenBookingNotFound() {
+            // given
+            UUID nonExistentId = UUID.randomUUID();
+            given(calendarService.generateBookingCalendar(nonExistentId))
+                    .willThrow(new ResourceNotFoundException("預約", "id", nonExistentId));
+
+            // when & then
+            assertThatThrownBy(() -> bookingController.downloadCalendar(nonExistentId))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/com/pet/service/CalendarServiceTest.java
+++ b/src/test/java/com/pet/service/CalendarServiceTest.java
@@ -1,0 +1,288 @@
+package com.pet.service;
+
+import com.pet.domain.Booking;
+import com.pet.domain.Dog;
+import com.pet.domain.Pet;
+import com.pet.domain.Sitter;
+import com.pet.exception.ResourceNotFoundException;
+import com.pet.repository.BookingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CalendarService 單元測試")
+class CalendarServiceTest {
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    @InjectMocks
+    private CalendarService calendarService;
+
+    private UUID testBookingId;
+    private Booking testBooking;
+    private Pet testPet;
+    private Sitter testSitter;
+
+    @BeforeEach
+    void setUp() {
+        testBookingId = UUID.randomUUID();
+
+        testPet = new Dog();
+        testPet.setName("喵喵");
+
+        testSitter = new Sitter();
+        testSitter.setName("張保母");
+
+        testBooking = new Booking();
+        testBooking.setId(testBookingId);
+        testBooking.setPet(testPet);
+        testBooking.setSitter(testSitter);
+        testBooking.setStartTime(LocalDateTime.of(2026, 1, 30, 9, 0));
+        testBooking.setEndTime(LocalDateTime.of(2026, 1, 30, 17, 0));
+        testBooking.setTotalPrice(1628.0);
+        testBooking.setStatus(Booking.BookingStatus.CONFIRMED);
+        testBooking.setNotes("測試備註");
+        testBooking.setCreatedAt(LocalDateTime.of(2026, 1, 27, 10, 0));
+    }
+
+    @Nested
+    @DisplayName("generateBookingCalendar - 產生行事曆")
+    class GenerateBookingCalendarTests {
+
+        @Test
+        @DisplayName("應該產生有效的 iCalendar 內容")
+        void shouldGenerateValidIcsContent() {
+            // given
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).startsWith("BEGIN:VCALENDAR");
+            assertThat(ics).endsWith("END:VCALENDAR\r\n");
+            assertThat(ics).contains("VERSION:2.0");
+            assertThat(ics).contains("METHOD:PUBLISH");
+        }
+
+        @Test
+        @DisplayName("應該包含正確的時區定義")
+        void shouldContainTimezoneDefinition() {
+            // given
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("BEGIN:VTIMEZONE");
+            assertThat(ics).contains("TZID:Asia/Taipei");
+            assertThat(ics).contains("X-WR-TIMEZONE:Asia/Taipei");
+            assertThat(ics).contains("TZOFFSETFROM:+0800");
+            assertThat(ics).contains("TZOFFSETTO:+0800");
+        }
+
+        @Test
+        @DisplayName("應該包含正確的事件資訊")
+        void shouldContainCorrectEventInfo() {
+            // given
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("BEGIN:VEVENT");
+            assertThat(ics).contains("SUMMARY:寵物保母預約 - 喵喵");
+            assertThat(ics).contains("DTSTART;TZID=Asia/Taipei:20260130T090000");
+            assertThat(ics).contains("DTEND;TZID=Asia/Taipei:20260130T170000");
+            assertThat(ics).contains("STATUS:CONFIRMED");
+            assertThat(ics).contains("UID:booking-" + testBookingId + "@petcare.com");
+        }
+
+        @Test
+        @DisplayName("應該包含寵物和保母資訊在描述中")
+        void shouldContainDescriptionWithDetails() {
+            // given
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("寵物：喵喵");
+            assertThat(ics).contains("保母：張保母");
+            assertThat(ics).contains("費用：$1628");
+            assertThat(ics).contains("狀態：已確認");
+        }
+
+        @Test
+        @DisplayName("應該包含備註資訊")
+        void shouldContainNotes() {
+            // given
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("備註：測試備註");
+        }
+
+        @Test
+        @DisplayName("沒有備註時不應包含備註欄位")
+        void shouldNotContainNotesWhenEmpty() {
+            // given
+            testBooking.setNotes(null);
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).doesNotContain("備註：");
+        }
+
+        @Test
+        @DisplayName("應該包含兩個提醒")
+        void shouldContainTwoAlarms() {
+            // given
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            // 1 小時前提醒
+            assertThat(ics).contains("TRIGGER:-PT1H");
+            assertThat(ics).contains("寵物保母預約提醒：喵喵 的保母服務即將開始");
+            // 1 天前提醒
+            assertThat(ics).contains("TRIGGER:-P1D");
+            assertThat(ics).contains("明天有寵物保母預約：喵喵");
+        }
+
+        @Test
+        @DisplayName("應該使用 createdAt 作為 DTSTAMP")
+        void shouldUseCreatedAtAsDtstamp() {
+            // given
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("DTSTAMP:20260127T100000");
+        }
+
+        @Test
+        @DisplayName("createdAt 為 null 時應使用 startTime 作為 DTSTAMP")
+        void shouldUseStartTimeWhenCreatedAtIsNull() {
+            // given
+            testBooking.setCreatedAt(null);
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("DTSTAMP:20260130T090000");
+        }
+    }
+
+    @Nested
+    @DisplayName("狀態對應測試")
+    class StatusMappingTests {
+
+        @Test
+        @DisplayName("PENDING 狀態應對應 TENTATIVE")
+        void pendingShouldMapToTentative() {
+            // given
+            testBooking.setStatus(Booking.BookingStatus.PENDING);
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("STATUS:TENTATIVE");
+            assertThat(ics).contains("狀態：待確認");
+        }
+
+        @Test
+        @DisplayName("CANCELLED 狀態應對應 CANCELLED")
+        void cancelledShouldMapToCancelled() {
+            // given
+            testBooking.setStatus(Booking.BookingStatus.CANCELLED);
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("STATUS:CANCELLED");
+            assertThat(ics).contains("狀態：已取消");
+        }
+
+        @Test
+        @DisplayName("REJECTED 狀態應對應 CANCELLED")
+        void rejectedShouldMapToCancelled() {
+            // given
+            testBooking.setStatus(Booking.BookingStatus.REJECTED);
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("STATUS:CANCELLED");
+            assertThat(ics).contains("狀態：已拒絕");
+        }
+
+        @Test
+        @DisplayName("COMPLETED 狀態應對應 TENTATIVE")
+        void completedShouldMapToTentative() {
+            // given
+            testBooking.setStatus(Booking.BookingStatus.COMPLETED);
+            given(bookingRepository.findById(testBookingId)).willReturn(Optional.of(testBooking));
+
+            // when
+            String ics = calendarService.generateBookingCalendar(testBookingId);
+
+            // then
+            assertThat(ics).contains("STATUS:TENTATIVE");
+            assertThat(ics).contains("狀態：已完成");
+        }
+    }
+
+    @Nested
+    @DisplayName("例外處理測試")
+    class ExceptionTests {
+
+        @Test
+        @DisplayName("預約不存在時應拋出 ResourceNotFoundException")
+        void shouldThrowWhenBookingNotFound() {
+            // given
+            UUID nonExistentId = UUID.randomUUID();
+            given(bookingRepository.findById(nonExistentId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> calendarService.generateBookingCalendar(nonExistentId))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+}


### PR DESCRIPTION
…NE notification link

- Add CalendarService to generate iCalendar (.ics) files for bookings
- Expose public endpoints for calendar page and .ics download in BookingController
- Update LINE notification to include calendar link if base URL is configured
- Add environment variable LINE_BASE_URL to configs and docker-compose files
- Update SecurityConfig to allow calendar endpoints without authentication
- Improve README and environment management for multi-device calendar support
- Add unit tests for CalendarService and BookingController calendar endpoints